### PR TITLE
Emad/rollback rudder android version to 1.0.10

### DIFF
--- a/packages/analytics/pubspec.lock
+++ b/packages/analytics/pubspec.lock
@@ -48,7 +48,7 @@ packages:
     description:
       path: "packages/deriv_rudderstack"
       ref: dev
-      resolved-ref: c19aa0f3ba5780d099986bcf9f75deb7c5a00ba7
+      resolved-ref: fcb0e230fcc30cbb3cf85c5d27661a6931921124
       url: "git@github.com:regentmarkets/flutter-deriv-packages.git"
     source: git
     version: "1.1.0"

--- a/packages/deriv_rudderstack/android/build.gradle
+++ b/packages/deriv_rudderstack/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.4.21'
-    ext.rudderstack_version = '1.0.21'
+    ext.rudderstack_version = '1.0.10'
     ext.gson_version = '2.8.6'
     repositories {
         google()


### PR DESCRIPTION
there is an issue with rudder latest verison on android so we rollback to the previous verison