### PR TITLE
Muhsin - Fixed form builder throwing an error for form fields with the same name

### DIFF
--- a/packages/form_builder/lib/form_builder/form_builder.dart
+++ b/packages/form_builder/lib/form_builder/form_builder.dart
@@ -85,8 +85,6 @@ class FormBuilderState extends State<FormBuilder> {
   /// Registers the form field with the given unique name in the form fields.
   void registerField(String name, dynamic field) {
     if (controller.fields.containsKey(name)) {
-      unregisterField(name, field);
-
       // It is safe to replace the new field with the old one that has the same key,
       // In such case [FormBuilder] will only care about the last one and ignore the
       // old one.


### PR DESCRIPTION
Fixing this issue 
https://redmine.deriv.cloud/issues/64844#Muhsin/Fix_%60FormBuilder%60_exception_%60A_field_with_the_same_name_already_exists%60 

Related PR: https://github.com/regentmarkets/flutter-otc-cashier/pull/1050