### PR TITLE
fix(deriv_ui): validating secondary currency instead of main currency in numpad

### DIFF
--- a/packages/deriv_ui/lib/components/numpad/widgets/number_pad.dart
+++ b/packages/deriv_ui/lib/components/numpad/widgets/number_pad.dart
@@ -456,6 +456,14 @@ class _NumberPadState extends State<NumberPad> {
     if (onValidate == null) {
       return null;
     } else {
+      if (ExchangeNotifier.of(context) != null) {
+        final String? amountInString =
+            ExchangeNotifier.of(context)?.finalAmount() != 0.0
+                ? ExchangeNotifier.of(context)?.finalAmount().toString()
+                : '';
+        final RichText? richText = onValidate(amountInString ?? '')?.text;
+        return richText;
+      }
       final RichText? richText =
           onValidate(_firstInputController?.text ?? '')?.text;
       return richText;

--- a/packages/deriv_ui/lib/components/numpad/widgets/number_pad_keypad.dart
+++ b/packages/deriv_ui/lib/components/numpad/widgets/number_pad_keypad.dart
@@ -63,6 +63,14 @@ class _NumberPadKeypadWidgetState extends State<_NumberPadKeypadWidget> {
     if (validate == null) {
       return true;
     } else {
+      if (ExchangeNotifier.of(context) != null) {
+        final String? amountInString =
+            ExchangeNotifier.of(context)?.finalAmount() != 0.0
+                ? ExchangeNotifier.of(context)?.finalAmount().toString()
+                : '';
+        final NumpadValidationText? result = validate(amountInString ?? '');
+        return result == null || result.enableActionButton;
+      }
       final NumpadValidationText? result =
           validate(provider.firstInputController!.text);
       final bool noError = result == null || result.enableActionButton;


### PR DESCRIPTION

<!-- Please refer to this [guide](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) for any confusion while creating the PR -->

**Clickup link:** https://app.clickup.com/t/20696747/DERG-1955


This PR contains the following changes:
- Return primary currency for validation instead of secondary currency when swapped.

<!-- Provide a description or list of changes -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore


## Pre-launch Checklist (For PR creator)

As a creator of this PR:

<!-- Put an `x` in all the boxes that apply ([x]) -->

- [x] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [x] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [x] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [x] 📝 I have added documentation, comments and logging wherever required.
- [ ] 🧪 I have added necessary tests for these changes.
- [ ] 🔎 I have ensured all existing tests are passing.

## Reviewers

@waqas-younas-deriv 

## Pre-launch Checklist (For Reviewers)

As a reviewer I ensure that:

- [ ] ✴️ This PR follows the standard PR template.
- [ ] 🪩 The information in this PR properly reflects the code changes.
- [ ] 🧪 All the necessary tests for this PR's are passing.

## Pre-launch Checklist (For QA)

- [ ] 👌 It passes the acceptance criteria.

## Pre-launch Checklist (For Maintainer)

- [ ] [MAINTAINER_NAME] I make sure this PR fulfills its purpose.
