### PR TITLE
feat(deriv_lint): update lint rules

### DIFF
--- a/packages/deriv_lint/lib/analysis_options.yaml
+++ b/packages/deriv_lint/lib/analysis_options.yaml
@@ -4,80 +4,118 @@ analyzer:
     - lib/basic_api/**
     - lib/generated/**
     - /**.g.dart
+    - lib/**firebase_options.dart
+    - test/.test_coverage.dart
+    - lib/generated_plugin_registrant.dart
+    - lib/**/router_config.g.dart
 
   language:
+    strict-casts: true
+    strict-inference: true
     strict-raw-types: true
 
   errors:
+    close_sinks: ignore
+    missing_required_param: error
+    missing_return: error
+    record_literal_one_positional_no_trailing_comma: error
+    collection_methods_unrelated_type: warning
+    unrelated_type_equality_checks: warning
+    public_member_api_docs: ignore
+    invalid_assignment: ignore
+    argument_type_not_assignable: ignore
     todo: ignore
-    missing_required_param: warning
-    missing_return: warning
-    # https://github.com/flutter/flutter/pull/24528
-    sdk_version_async_exported_from_core: ignore
 
 linter:
   rules:
-    # Taken from https://github.com/dart-lang/linter/blob/master/example/all.yaml
     - always_declare_return_types
-    - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    - always_require_non_null_named_parameters
-    - always_specify_types
+    - always_use_package_imports
     - annotate_overrides
     - avoid_bool_literals_in_conditional_expressions
-    - avoid_catches_without_on_clauses
+    - avoid_catching_errors
+    - avoid_double_and_int_checks
+    - avoid_dynamic_calls
     - avoid_empty_else
     - avoid_equals_and_hash_code_on_mutable_classes
+    - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
+    - avoid_final_parameters
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null
+    - avoid_js_rounded_ints
+    - avoid_multiple_declarations_per_line
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
     - avoid_print
+    - avoid_private_typedef_functions
     - avoid_redundant_argument_values
     - avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
-    - avoid_returning_null
-    - avoid_returning_null_for_future
     - avoid_returning_null_for_void
+    - avoid_returning_this
     - avoid_setters_without_getters
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_slow_async_io
+    - avoid_type_to_string
     - avoid_types_as_parameter_names
-    # - avoid_types_on_closure_parameters
     - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
     - avoid_void_async
+    - avoid_web_libraries_in_flutter
     - await_only_futures
+    - camel_case_extensions
     - camel_case_types
     - cancel_subscriptions
     - cascade_invocations
-    - close_sinks
-    # - comment_references
+    - cast_nullable_to_non_nullable
+    - collection_methods_unrelated_type
+    - combinators_ordering
+    - comment_references
+    - conditional_uri_does_not_exist
     - constant_identifier_names
     - control_flow_in_finally
     - curly_braces_in_flow_control_structures
-    # - directives_ordering
+    - dangling_library_doc_comments
+    - depend_on_referenced_packages
+    - deprecated_consistency
+    - directives_ordering
     - empty_catches
     - empty_constructor_bodies
     - empty_statements
-    # - exhaustive_cases # required SDK 2.9.0
+    - eol_at_end_of_file
+    - exhaustive_cases
     - file_names
     - flutter_style_todos
     - hash_and_equals
+    - implicit_call_tearoffs
     - implementation_imports
-    - iterable_contains_unrelated_type
+    - implicit_reopen
+    - invalid_case_patterns
     - join_return_with_assignment
+    - leading_newlines_in_multiline_strings
+    - library_annotations
     - library_names
     - library_prefixes
+    - library_private_types_in_public_api
     - lines_longer_than_80_chars
-    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
+    - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
+    - no_default_cases
     - no_duplicate_case_values
+    - no_leading_underscores_for_library_prefixes
+    - no_leading_underscores_for_local_identifiers
+    - no_logic_in_create_state
+    - no_runtimeType_toString
     - non_constant_identifier_names
+    - noop_primitive_operations
+    - null_check_on_nullable_type_parameter
     - null_closures
+    - omit_local_variable_types
+    - one_member_abstracts
     - only_throw_errors
     - overridden_fields
     - package_api_docs
@@ -86,6 +124,7 @@ linter:
     - parameter_assignments
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
+    - prefer_asserts_with_message
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -94,49 +133,86 @@ linter:
     - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
-    - prefer_expression_function_bodies # https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
-    - prefer_foreach
+    - prefer_for_elements_to_map_fromIterable
     - prefer_function_declarations_over_variables
     - prefer_generic_function_type_aliases
+    - prefer_if_elements_to_conditional_expressions
+    - prefer_if_null_operators
     - prefer_initializing_formals
+    - prefer_inlined_adds
     - prefer_int_literals
     - prefer_interpolation_to_compose_strings
     - prefer_is_empty
     - prefer_is_not_empty
+    - prefer_is_not_operator
     - prefer_iterable_whereType
-    - prefer_mixin
+    - prefer_null_aware_method_calls
+    - prefer_null_aware_operators
     - prefer_single_quotes
+    - prefer_spread_collections
     - prefer_typing_uninitialized_variables
     - prefer_void_to_null
+    - provide_deprecation_message
     - public_member_api_docs
     - recursive_getters
+    - require_trailing_commas
+    - secure_pubspec_urls
+    - sized_box_for_whitespace
+    - sized_box_shrink_expand
     - slash_for_doc_comments
+    - sort_child_properties_last
     - sort_constructors_first
-    # - sort_pub_dependencies
+    - sort_pub_dependencies
     - sort_unnamed_constructors_first
     - test_types_in_equals
     - throw_in_finally
+    - tighten_type_of_initializing_formals
+    - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures
     - unnecessary_await_in_return
+    - unnecessary_breaks
     - unnecessary_brace_in_string_interps
     - unnecessary_const
+    - unnecessary_constructor_name
     - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_late
+    - unnecessary_library_directive
     - unnecessary_new
     - unnecessary_null_aware_assignments
+    - unnecessary_null_checks
     - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
     - unnecessary_overrides
     - unnecessary_parenthesis
+    - unnecessary_raw_strings
     - unnecessary_statements
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
     - unnecessary_this
+    - unnecessary_to_list_in_spreads
     - unrelated_type_equality_checks
+    - use_build_context_synchronously
+    - use_colored_box
+    - use_enums
+    - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
+    - use_if_null_to_convert_nulls_to_bools
+    - use_is_even_rather_than_modulo
+    - use_key_in_widget_constructors
+    - use_late_for_private_fields_and_variables
+    - use_named_constants
+    - use_raw_strings
     - use_rethrow_when_possible
     - use_setters_to_change_properties
     - use_string_buffers
+    - use_string_in_part_of_directives
+    - use_super_parameters
+    - use_test_throws_matchers
     - use_to_and_as_if_applicable
     - valid_regexps
     - void_checks


### PR DESCRIPTION

**Clickup link:** https://app.clickup.com/t/20696747/DERG-2271

This PR contains the following changes:
- updated to the latest researched lint rules
<!-- Provide a description or list of changes -->

- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore

### Developers Note (Optional)

<!-- REMOVE THIS SECTION IF IT IS NOT NEEDED.>

<!-- Add the reason of making changes in this approach so that it will be helpful to reviewers while reviewing it. -->

## Pre-launch Checklist (For PR creator)

As a creator of this PR:

<!-- Put an `x` in all the boxes that apply ([x]) -->

- [x] ✍️ I have included clickup id and package/app_name in the PR title. <!-- Find the guide [here](https://github.com/regentmarkets/flutter-deriv-packages/blob/master/.github/GIT_RULES.md#pr-rules) -->
- [x] 👁️ I have gone through the code and removed any temporary changes (commented lines, prints, debug statements etc.).
- [x] ⚒️ I have fixed any errors/warnings shown by the analyzer/linter.
- [x] 📝 I have added documentation, comments and logging wherever required.
- [x] 🧪 I have added necessary tests for these changes.
- [x] 🔎 I have ensured all existing tests are passing.

## Reviewers
@sahani-deriv @ramin-deriv @abedelaziz-deriv 
<!-- Tag the reviewers of this PR -->

## Pre-launch Checklist (For Reviewers)

As a reviewer I ensure that:

- [ ] ✴️ This PR follows the standard PR template.
- [ ] 🪩 The information in this PR properly reflects the code changes.
- [ ] 🧪 All the necessary tests for this PR's are passing.

## Pre-launch Checklist (For QA)

- [ ] 👌 It passes the acceptance criteria.

## Pre-launch Checklist (For Maintainer)

- [ ] [MAINTAINER_NAME] I make sure this PR fulfills its purpose.
